### PR TITLE
Add logic to load preset on startup if not already loaded

### DIFF
--- a/midi2piousbhub.h
+++ b/midi2piousbhub.h
@@ -227,5 +227,6 @@ namespace rppicomidi
         #endif
         Midi2PioUsbhub_cli cli;
         bool cdc_state_has_changed;
+        bool preset_loaded;
     };
 }


### PR DESCRIPTION
A new `preset_loaded` flag was introduced to ensure presets are tentatively loaded once during initialization. The logic checks for a delay before attempting to load the current preset, and avoids retries on failure.